### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: ["^13.0", "^12.0", "^11.0", "^10.0"]
+        laravel: ["^13.0", "^12.0", "^11.0"]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: "^13.0"
@@ -23,8 +23,6 @@ jobs:
             testbench: 10.*
           - laravel: "^11.0"
             testbench: 9.*
-          - laravel: "^10.0"
-            testbench: 8.*
         exclude:
           - laravel: "^13.0"
             php: 8.2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,7 +56,7 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Remove larastan from dev dependencies
-        run: composer remove --dev nunomaduro/larastan
+        run: composer remove --dev nunomaduro/larastan --no-update
 
       - name: Upgrade Pest for Laravel 13
         if: matrix.laravel == '^13.0'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2, 8.1]
-        laravel: ["^12.0", "^11.0", "^10.0"]
+        laravel: ["^13.0", "^12.0", "^11.0", "^10.0"]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: "^13.0"
+            testbench: 11.*
           - laravel: "^12.0"
             testbench: 10.*
           - laravel: "^11.0"
@@ -24,6 +26,12 @@ jobs:
           - laravel: "^10.0"
             testbench: 8.*
         exclude:
+          - laravel: "^13.0"
+            php: 8.1
+          - laravel: "^13.0"
+            php: 8.2
+          - laravel: "^13.0"
+            stability: prefer-lowest
           - laravel: "^11.0"
             php: 8.1
           - laravel: "^12.0"
@@ -49,6 +57,10 @@ jobs:
 
       - name: Remove larastan from dev dependencies
         run: composer remove --dev nunomaduro/larastan
+
+      - name: Upgrade Pest for Laravel 13
+        if: matrix.laravel == '^13.0'
+        run: composer require 'pestphp/pest:^4.0' 'pestphp/pest-plugin-laravel:^4.0' --dev --no-update
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2]
         laravel: ["^13.0", "^12.0", "^11.0", "^10.0"]
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -27,15 +27,9 @@ jobs:
             testbench: 8.*
         exclude:
           - laravel: "^13.0"
-            php: 8.1
-          - laravel: "^13.0"
             php: 8.2
           - laravel: "^13.0"
             stability: prefer-lowest
-          - laravel: "^11.0"
-            php: 8.1
-          - laravel: "^12.0"
-            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "composer/semver": "^3.4",
         "laravel/pint": "^1.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0",
         "phpstan/extension-installer": "^1.1",
         "spatie/laravel-ray": "^1.26"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
@@ -24,8 +24,8 @@
         "laravel/pint": "^1.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
         "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^2.9|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.9|^3.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "phpstan/extension-installer": "^1.1",
         "spatie/laravel-ray": "^1.26"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "composer/semver": "^3.4",
         "laravel/pint": "^1.0",
         "nunomaduro/larastan": "^2.0.1|^3.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "pestphp/pest": "^2.9|^3.0",
         "pestphp/pest-plugin-laravel": "^2.9|^3.0",
         "phpstan/extension-installer": "^1.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,16 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
     <source>
         <include>
             <directory suffix=".php">./src</directory>


### PR DESCRIPTION
This PR adds Laravel 13 support and modernizes the CI/dependency setup:

## Changes
- **Added Laravel 13 support** (`^13.0` for `illuminate/contracts`, `^11.0` for `orchestra/testbench`)
- **Dropped Laravel 10** (EOL since Feb 2025)
- **Dropped PHP 8.1** (incompatible with current pest/phpunit ecosystem)
- **Upgraded Pest** to `^3.0` (base), with Pest 4.x for Laravel 13 CI runs
- **Fixed CI**: `--no-update` flag for larastan removal, modernized phpunit.xml.dist
- **CI matrix**: L13 tested on PHP 8.3+ with prefer-stable only

## Compatibility
- PHP ^8.2
- Laravel 11, 12, 13